### PR TITLE
build: add clean_fast target to preserve banim compression outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,21 @@ compare: $(ROM)
 
 .PHONY: compare
 
+clean_fast:
+	$(RM) $(ROM) $(ELF) $(MAP) $(C_OBJECTS) $(ASM_OBJECTS) $(MID_OBJECTS) $(OBJECTS_LST) $(SFILES_COMPILED) graphics/*.h $(CFILES_GENERATED)
+	$(RM) -rf $(DEPS_DIR)
+	# Remove TSA files generated from tilemaps
+	$(RM) -f graphics/statscreen/*.bin
+	# Remove converted sound samples
+	$(RM) -f $(SAMPLE_SUBDIR)/*.bin
+	$(RM) -f $(MAP_LAYOUT_SUBDIR)/*.bin
+	# Remove converted songs
+	$(RM) -f $(MID_SUBDIR)/*.s
+	$(RM) -f $(AUTO_GEN_TARGETS)
+	@find . \( -iname '*.o' -o -iname '*.obj' -o -iname '*.feimg*.bin'  -o -iname '*.fetsa*.bin' -o -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.fk' -o -iname '*.latfont' -o -iname '*.hwjpnfont' -o -iname '*.fwjpnfont' \) -not -path './data/banim/*' -exec rm {} +
+
+.PHONY: clean_fast
+
 clean:
 	$(RM) $(ROM) $(ELF) $(MAP) $(ALL_OBJECTS) $(OBJECTS_LST) $(SFILES_COMPILED) graphics/*.h $(CFILES_GENERATED)
 	$(RM) -rf $(DEPS_DIR)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ If you just want to get the repo building quickly (Ubuntu/WSL, Arch Linux, or ma
 
 See [`docs/quickstart.md`](docs/quickstart.md) for full details, flags, and troubleshooting tips.
 
+### Building
+
+To build the ROM:
+```bash
+make fireemblem8.gba -j$(nproc)
+```
+To clean all build artifacts:
+```bash
+make clean
+```
+To clean all build artifacts **except** the extremely slow battle animation compression outputs:
+```bash
+make clean_fast
+```
+
 ### Setting up the repository manually
 
 1. You must have a copy of the Fire Emblem: The Sacred Stones ROM named `baserom.gba` in the repository directory.


### PR DESCRIPTION
## Description
The `arm_compressing_linker` pipeline for `data_banim.o` is extremely slow. This adds a `make clean_fast` target which cleans the repository exactly like `make clean`, but skips deleting `data/banim/*`, preserving the intermediate banim object files and their compressed assets to save massive amounts of time on rebuilds.

### Changes
- Added `clean_fast` target to `Makefile`
- Documented `clean_fast` in `README.md`

---
Agent: Rennac | Model: github-copilot/claude-opus-4.6 | OpenClaw: 2026.2.25
*internal review feedback from my owner (@laqieer) applied*